### PR TITLE
Redirect to search page when not found.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ page will use the existing search index of the project to redirect to the page
 where the entity is located.
 For example, if you have a page `api.html` where a Python function `f` is
 documented, then its permalink may be `https://example.com/api.html#f`. If you
-then browse to `https://example.api.html?q=f` you will be redirected to 
+then browse to `https://example.api.html?q=f` you will be redirected to
 `https://example.com/api.html#f`.
+If the entry is not found, then it redirects to search.html page with the same
+question string.
 
 ## Installation
 

--- a/sphinx_redirect_by_id/redirect.html_t
+++ b/sphinx_redirect_by_id/redirect.html_t
@@ -18,9 +18,9 @@
   {{ super() }}
 {% endblock %}
 {% block body %}
-  <h1 id="redirect-by-id">{{ _('Redirect by ID') }}</h1>
   {% block scriptwarning %}
   <noscript>
+  <h1 id="redirect-by-id">{{ _('Redirect by ID') }}</h1>
   <div class="admonition warning">
   <p>
     {% trans %}Please activate JavaScript to enable the redirection

--- a/sphinx_redirect_by_id/redirecttools.js
+++ b/sphinx_redirect_by_id/redirecttools.js
@@ -26,10 +26,8 @@ var Redirect = {
       const query = new URLSearchParams(window.location.search).get("q");
       if(query) {
           Redirect.performSearch(query);
-      } else {
-          const out = document.getElementById('search-results');
-          out.innerHTML = '<p>No query ID provided. Use <code>?q=theId</code> to redirect.</p>';
-      }
+      } else
+        Redirect.redirectToSearch('');
   },
 
   setIndex: function(index) {
@@ -53,12 +51,6 @@ var Redirect = {
    * perform a search for ID (or wait until index is loaded)
    */
   performSearch: function(query) {
-    // create the required interface elements
-    this.out = document.getElementById('search-results');
-    this.title = document.createElement('h2');
-	this.out.appendChild(this.title);
-    this.title.innerHTML = _('Searching') + '...';
-
     // index already loaded, the browser was quick!
     if(this.hasIndex())
       this.query(query);
@@ -92,9 +84,8 @@ var Redirect = {
       }
       var fullUrl = linkUrl + result[1];
       window.location.replace(fullUrl);
-    } else {
-      this.title.innerHTML = _('ID not found') + ": " + query;
-    }
+    } else
+      Redirect.redirectToSearch(query);
   },
 
   /**
@@ -123,6 +114,18 @@ var Redirect = {
     }
     return null;
   },
+
+  redirectToSearch: function(query) {
+    var search_url = '';
+    if(DOCUMENTATION_OPTIONS.BUILDER === 'dirhtml')
+      search_url = DOCUMENTATION_OPTIONS.URL_ROOT + 'search';
+    else
+      search_url = DOCUMENTATION_OPTIONS.URL_ROOT + 'search' + DOCUMENTATION_OPTIONS.FILE_SUFFIX;
+
+    if (query)
+      search_url += '?q=' + query;
+    window.location.replace(search_url);
+  }
 };
 
 _ready(Redirect.init);


### PR DESCRIPTION
The commit simplifies the plug-in by simply redirecting to search
page when a result is not found.

My motivation is that I would like to use the plug-in in `furo` template that does not provide `layout.html`.